### PR TITLE
Update net.cpp

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -57,7 +57,7 @@ static bool vfLimited[NET_MAX] = {};
 static CNode* pnodeLocalHost = NULL;
 CAddress addrSeenByPeer(CService("0.0.0.0", 0), nLocalServices);
 uint64 nLocalHostNonce = 0;
-array<int, THREAD_MAX> vnThreadsRunning;
+boost::array<int, THREAD_MAX> vnThreadsRunning;
 static std::vector<SOCKET> vhListenSocket;
 CAddrMan addrman;
 


### PR DESCRIPTION
Fixing compile error: src/net.cpp:60:1: error: reference to ‘array’ is ambiguous

Referencing issue #13: https://github.com/magi-project/magi/issues/13